### PR TITLE
Fix error when creating a WebApplication or a DBSchema

### DIFF
--- a/cluster-ci/datamodel.cluster-ci.xml
+++ b/cluster-ci/datamodel.cluster-ci.xml
@@ -240,7 +240,6 @@
         <field id="dbserver_id" _delta="delete" />
         <field id="dbserver_name" _delta="delete"/>
         <field id="softwareinstance_id" xsi:type="AttributeExternalKey" _delta="define">
-          <sql>dbserver_id</sql>
           <sql>softwareinstance_id</sql>
           <target_class>SoftwareInstance</target_class>
           <is_null_allowed>false</is_null_allowed>
@@ -296,7 +295,6 @@
         <field id="webserver_id" _delta="delete" />
         <field id="webserver_name" _delta="delete"/>
         <field id="softwareinstance_id" xsi:type="AttributeExternalKey" _delta="define">
-          <sql>webserver_id</sql>
           <sql>softwareinstance_id</sql>
           <target_class>SoftwareInstance</target_class>
           <is_null_allowed>false</is_null_allowed>


### PR DESCRIPTION
**Symptom**
Error when creating a WebApplication (or a DBSchema), message says "unknown webserver_id attribute".

**Reproduction**
  * iTop 3.1
  * Try to create a WebApplication

**Cause**
In both classes a field is defined with a duplicated `<sql>` node which confuses iTop.

**Solution**
Remove the duplicated `sql` node to only keep the correct one.